### PR TITLE
Update tomato.gg URLs: the realm comes after the player identifiers.

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -48,7 +48,7 @@ pub fn player_color_for_team_relation(relation: u32) -> Color32 {
 
 pub fn build_tomato_gg_url(entity: &VehicleEntity) -> Option<String> {
     let player = entity.player()?;
-    Some(format!("https://tomato.gg/wows/stats/{}/{}-{}", player.realm(), player.name(), player.db_id()))
+    Some(format!("https://tomato.gg/wows/stats/{}-{}/{}", player.name(), player.db_id(), player.realm()))
 }
 
 pub fn build_wows_numbers_url(entity: &VehicleEntity) -> Option<String> {


### PR DESCRIPTION
This fixes links to Tomato.gg profiles: these URLs are `name-id/realm`, not `realm/name-id`.